### PR TITLE
Fail silently when trying to load various XML parsers

### DIFF
--- a/lib/oembed_links.rb
+++ b/lib/oembed_links.rb
@@ -305,7 +305,7 @@ class OEmbed
         self.register_formatter(OEmbed::Formatters::LibXML)
         loaded_lib = true
       rescue LoadError
-        puts "Error loading LibXML XML formatter"
+        # Silently fail: LibXML XML formatter not found
       end
     end
     unless loaded_lib || ignore.include?("hpricot")
@@ -315,7 +315,7 @@ class OEmbed
         self.register_formatter(OEmbed::Formatters::HpricotXML)        
         loaded_lib = true
       rescue LoadError
-        puts "Error loading Hpricot XML formatter"
+        # Silently fail: Hpricot XML formatter not found
       end      
     end
     unless loaded_lib || ignore.include?("rexml")


### PR DESCRIPTION
We have RubyXML loaded but every time we load up our Rails environment in a console, run a rake task, or start a dev server, we see the following messages:

Error loading LibXML XML formatter
Error loading Hpricot XML formatter

They are both unnecessary communication. It doesn't matter what fails to load unless it's critical and there is a StandardError thrown if no valid XML parser is found. I was just hoping to reduce the noise. Let me know if you have any questions.

-Ryan
